### PR TITLE
Change to GitHub and other nits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "serpent-style"]
 	path = serpent-style
-	url = git@gitlab.com:serpent-os/core/serpent-style.git
+	url = git@github.com:serpent-os/serpent-style.git

--- a/content/about.md
+++ b/content/about.md
@@ -27,7 +27,7 @@ matrix.org or in our development channel, [#serpentos-dev](https://matrix.to/#/#
 If your matrix client supports spaces (app.element.io does), you can join the [Serpent OS matrix Space](https://matrix.to/#/!trFJOzhpDUejJKnPYg:matrix.org)
 which will show all the channels offered by us.
 
-You can also join us at [GitLab](https://gitlab.com/serpent-os) where you'll find all our code, tools and packaging
+You can also join us on [GitHub](https://github.com/serpent-os) where you'll find all our code, tools and packaging
 repositories. This is where users are able to contribute and improve Serpent OS.
 
 We want to enjoy working on Serpent OS, and we want you to as well. If there is anything that is impacting on your ability to enjoy

--- a/content/about.md
+++ b/content/about.md
@@ -27,7 +27,7 @@ matrix.org or in our development channel, [#serpentos-dev](https://matrix.to/#/#
 If your matrix client supports spaces (app.element.io does), you can join the [Serpent OS matrix Space](https://matrix.to/#/!trFJOzhpDUejJKnPYg:matrix.org)
 which will show all the channels offered by us.
 
-You can also join us on [GitHub](https://github.com/serpent-os) where you'll find all our code, tools and packaging
+You can also join us at [GitHub](https://github.com/serpent-os) where you'll find all our code, tools and packaging
 repositories. This is where users are able to contribute and improve Serpent OS.
 
 We want to enjoy working on Serpent OS, and we want you to as well. If there is anything that is impacting on your ability to enjoy

--- a/content/download.md
+++ b/content/download.md
@@ -9,8 +9,7 @@ Callout: "Grab them ISOs"
 
 Looks like we haven't released any ISOs yet!
 
-We're working towards our [0.0 milestone](https://gitlab.com/groups/serpent-os/-/milestones/1#tab-issues),
-where we plan to release a fully functioning and self-hosting Serpent OS core system distributed as a
+We're working towards the of release a fully functioning and self-hosting Serpent OS core system distributed as a
 [systemd-nspawn container](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html).
 
 This container will enable interested parties to start developing Serpent OS packages, 

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -70,7 +70,7 @@ At times, we may link to or include third-party content on our website. These in
  - [Tenor](https://tenor.com/legal-terms)
  - [Twitter](https://twitter.com/en/privacy)
  - [YouTube](https://policies.google.com/privacy?hl=en-US)
- - [GitLab](https://about.gitlab.com/terms/)
+ - [GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement)
 
 The above links will take you to the terms of service and/or privacy policy for those websites. As such, those particular services **may** set cookies on your machine, or process data separately from Serpent OS. As such you should refer to their terms for how your data is processed.
 

--- a/content/team.md
+++ b/content/team.md
@@ -21,5 +21,5 @@ matrix.org or in our development channel, [#serpentos-dev](https://matrix.to/#/#
 If your matrix client supports spaces (app.element.io does), you can join the [Serpent OS matrix Space](https://matrix.to/#/!trFJOzhpDUejJKnPYg:matrix.org )
 which will show all the channels offered by us.
 
-You can also join us at [GitLab](https://gitlab.com/serpent-os) where you'll find all our code, tools and packaging
+You can also join us at [GitHub](https://github.com/serpent-os) where you'll find all our code, tools and packaging
 repositories. This is where users contribute and improve Serpent OS.

--- a/views/primary_navigation.dt
+++ b/views/primary_navigation.dt
@@ -11,13 +11,15 @@
 -   NavigationItem("/blog", "Blog"),
 -   NavigationItem("#", "Community", [
 -       NavigationItem("https://forums.serpentos.com", "Forums"),
--       NavigationItem("#", "Matrix")
+-       NavigationItem("https://matrix.to/#/!trFJOzhpDUejJKnPYg:matrix.org", "Matrix"),
+-       NavigationItem("https://github.com/serpent-os/serpentos.com", "Github"),
 -   ]),
 -   NavigationItem("/sponsors", "Sponsors"),
 -   NavigationItem("#", "Tooling", [
 -       NavigationItem("/boulder", "boulder"),
 -       NavigationItem("/moss", "moss"),
 -   ]),
+-   NavigationItem("/about", "About"),
 - ];
 
 nav.navbar.navbar-expand-lg.navbar-light.border-bottom.shadow-sm


### PR DESCRIPTION
- Change GitLab links to GitHub for pages which are not blog posts:
  - `Download`
  - `Team`
  - `About`
  - `Privacy`
- Point `serpent-style` submodule to GitHub
- Created drop-down entry for GitHub organization under Community
- Added a link to the Matrix dropdown entry to the Serpent-OS Matrix space
- Added `About` to the navigation bar

Additional notes:
- I had mentioned that I could not see how to navigate to Team. There is a link on the "Community" page