### PR TITLE
typo: BOIS => BIOS

### DIFF
--- a/content/en/docs/users/getting_started/requirements.md
+++ b/content/en/docs/users/getting_started/requirements.md
@@ -8,7 +8,7 @@ weight = 10
 ## Minimum System Requirements
 
 {{< alert color="info" >}}
-BOIS/CSM mode is not supported. Please ensure that your system is set to UEFI mode.
+BIOS/CSM mode is not supported. Please ensure that your system is set to UEFI mode.
 {{< /alert >}}
 
 - **Architecture:** x86_64


### PR DESCRIPTION
A minor typo was corrected